### PR TITLE
Small Markdown fix

### DIFF
--- a/Docs/Thor_install.md
+++ b/Docs/Thor_install.md
@@ -5,7 +5,7 @@
 
 ### Installing Thor
 
-1. [**Download current version of Thor**](https://github.com/VFPX/Thor/archive/master.zip).
+1. [Download current version of Thor](https://github.com/VFPX/Thor/archive/master.zip).
 2. Extract "Thor" sub-folder from the ZIP file to the installation folder of your choice (see details below on how to choose an installation folder). After this step your installation folder should only contain "Source" sub-folder and the Thor.APP.
 3. Open Visual FoxPro and run the following commands in the command window:
 

--- a/Docs/Thor_install.md
+++ b/Docs/Thor_install.md
@@ -31,7 +31,7 @@ The command does couple of things.
 
 #### Choosing an installation folder
 
-Thor must be installed into permanent folder; it creates some folders and tables which must always be available. We suggest to install Thor into a folder that is backed up on a regular basis. The installation folder doesn't need to be a VFP sub-folder. 
+Thor must be installed into permanent folder; it creates some folders and tables which must always be available. We suggest to install Thor into a folder that is backed up on a regular basis. The installation folder doesn't need to be a VFP sub-folder.
 
 There are two different strategies when selecting an installation folder for Thor:
 

--- a/Docs/Thor_install.md
+++ b/Docs/Thor_install.md
@@ -3,21 +3,21 @@
 
 *Note:* starting with Thor Version 1.1, Thor updates can be obtained by using [One-Click Update of Thor](Thor_one-click_update.md). This page only applies to the **initial installation** of Thor or should it happen that the One-Click Update is not working.
 
-### **Installing Thor**
+### Installing Thor
 
 1. [**Download current version of Thor**](https://github.com/VFPX/Thor/archive/master.zip).
 2. Extract "Thor" sub-folder from the ZIP file to the installation folder of your choice (see details below on how to choose an installation folder). After this step your installation folder should only contain "Source" sub-folder and the Thor.APP.
-3. Open Visual FoxPro and run the following commands in the command window:  
+3. Open Visual FoxPro and run the following commands in the command window:
 
 
-    Clear All
-    Do [C:\Path\To\ThorInstallFolder\Thor.APP]
+        Clear All
+        Do [C:\Path\To\ThorInstallFolder\Thor.APP]
 
-or, in case your Thor installation folder is in your PATH, simply:
+    or, in case your Thor installation folder is in your PATH, simply:
 
 
-    Clear All
-    Do Thor.APP
+        Clear All
+        Do Thor.APP
 
 The command does couple of things.
 


### PR DESCRIPTION
Codeblocks in the ordered list need to be indented with 8 spaces in order to show correctly on GitHub.